### PR TITLE
Refactor GitHub Actions workflow for Tauri app build and add AUR packaging steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,67 +1,100 @@
-name: 'publish'
+name: publish
 
 on:
     push:
         branches:
             - main
 
-# This workflow will trigger on each push to the `main` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
-
 jobs:
     publish-tauri:
         permissions:
             contents: write
+
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - platform: 'macos-latest' # for Arm based macs (M1 and above).
+                    - platform: macos-latest
                       args: '--target aarch64-apple-darwin'
-                    - platform: 'macos-latest' # for Intel based macs.
+                    - platform: macos-latest
                       args: '--target x86_64-apple-darwin'
-                    - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+                    - platform: ubuntu-22.04
                       args: ''
-                    - platform: 'windows-latest'
+                    - platform: windows-latest
                       args: ''
 
         runs-on: ${{ matrix.platform }}
-        steps:
-            - uses: actions/checkout@v4
 
-            - name: setup node
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: lts/*
 
-            - name: setup pnpm
+            - name: Setup PNPM
               uses: pnpm/action-setup@v4
               with:
                   version: 10
 
-            - name: install Rust stable
+            - name: Install Rust
               uses: dtolnay/rust-toolchain@stable
               with:
-                  # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
                   targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
-            - name: install dependencies (ubuntu only)
-              if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+            - name: Install Linux build deps
+              if: matrix.platform == 'ubuntu-22.04'
               run: |
                   sudo apt-get update
                   sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-              # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
-              # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
 
-            - name: install frontend dependencies
+            - name: Install frontend deps
               run: pnpm install
 
-            - uses: tauri-apps/tauri-action@v0
+            - name: Build Tauri app
+              uses: tauri-apps/tauri-action@v0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
-                  tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+                  tagName: app-v__VERSION__
                   releaseName: 'App v__VERSION__'
                   releaseBody: 'See the assets to download this version and install.'
                   releaseDraft: true
                   prerelease: false
                   args: ${{ matrix.args }}
+
+            - name: Prepare AUR PKGBUILD
+              if: matrix.platform == 'ubuntu-22.04'
+              run: |
+                  VERSION=$(jq -r .version < src-tauri/tauri.conf.json)
+                  ARCH=$(uname -m)
+                  PKGNAME=$(jq -r .identifier < src-tauri/tauri.conf.json)
+                  mkdir aur
+                  cat > aur/PKGBUILD << 'EOF'
+                  pkgname=$PKGNAME
+                  pkgver=$VERSION
+                  pkgrel=1
+                  pkgdesc="King God Castle Toolkit"
+                  arch=('x86_64' 'aarch64')
+                  url="https://github.com/${{ github.repository }}"
+                  license=('MIT')
+                  depends=('gtk3' 'libappindicator-gtk3')
+                  source=("${pkgname}-${pkgver}-${ARCH}.tar.zst::https://github.com/${{ github.repository }}/releases/download/app-v${pkgver}/${pkgname}-${pkgver}-${ARCH}.tar.zst")
+                  sha256sums=('SKIP')
+                  package() {
+                    install -Dm755 "${pkgname}-${pkgver}-${ARCH}.tar.zst" "$pkgdir/usr/bin/${pkgname}"
+                  }
+                  EOF
+
+            - name: Package for AUR
+              if: matrix.platform == 'ubuntu-22.04'
+              run: |
+                  mkdir -p aur/src
+                  VERSION=$(jq -r .version < src-tauri/tauri.conf.json)
+                  ARCH=$(uname -m)
+                  cp target/release/${{ matrix.args == '' && 'com.nowl.kgc-toolkit' || '' }} aur/src/com.nowl.kgc-toolkit-${VERSION}-${ARCH}.tar.zst
+                  cd aur
+                  tar czf ${PKGNAME}-${VERSION}.tar.gz PKGBUILD src
+                  ls -lah


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build.yml` to improve clarity, streamline the build process, and add packaging support for the Arch User Repository (AUR). The main changes include renaming steps for consistency, cleaning up comments, and introducing steps to generate and package an AUR `PKGBUILD` for Linux builds.

**Workflow improvements and clarity:**

* Renamed workflow steps to use consistent and descriptive names (e.g., "Setup Node.js", "Install Rust", "Install frontend deps") and removed unnecessary or outdated comments.
* Cleaned up the matrix configuration by removing redundant quotes and clarifying platform/target combinations.

**AUR packaging support:**

* Added a new step to generate a `PKGBUILD` file for the AUR, extracting version and package information from `src-tauri/tauri.conf.json` during Linux builds.
* Added a packaging step to bundle the built application and `PKGBUILD` into a tarball suitable for AUR submission, executed only on the `ubuntu-22.04` platform.